### PR TITLE
Changes arround rollback feature

### DIFF
--- a/sros/README.md
+++ b/sros/README.md
@@ -80,20 +80,22 @@ This Ansible collection also contains a playbook, on how to enable rollbacks:
 [sros_classic_cli_commission.yml](https://raw.githubusercontent.com/nokia/ansible-networking-collections/master/sros/playbooks/sros_classic_cli_commission.yml).
 
 Snapshot/rollback is used the following way:
-* New checkpoint is created on the begigining of plugin operation.
+* A new temporary rollback checkpoint is created at the beginning of every
+  cli_config operation.
 * If a configuration request runs into an error, the configuration is restored
-  by rolling back to the last checkpoint. It actually translates to a
-  rollback-on-error behavior.
-* After the configuration change was made, the running configuration is
-  compared against the previous checkpoint (supported nodal feature). This
-  is needed to provide the `change` indicator, but also to provide the
-  actual differences, if the `--diff` option was entered.
+  by rolling back to the checkpoint that was created before. This actually
+  translates to a rollback-on-error behavior.
+* If the configuration request is successful, the running configuration is
+  compared against the previous checkpoint using the underlying nodal feature.
+  This is needed to provide the `change` indicator, but also to provide the
+  actual differences, if the `--diff` option is used.
 * If operator requests to do a dry-run by providing the `--check` option,
   the change is actually executed against the running config and reverted
-  to the last checkpoint straight away. Following that approach, syntax and
+  to the checkpoint straight away. Following that approach, syntax and
   semantic checks will be executed - but also we get `change` indication
   including the list of differences, if `--diff` option was provided.
-* Created checkpoint is deleted just before the end of plugin operation.
+* At the end of the cli_config operation the checkpoint created will be
+  deleted to keep a clean rollback history.
 
 WARNING:
 * Be aware, that dry-run is implemented as short duration activation of the

--- a/sros/README.md
+++ b/sros/README.md
@@ -79,11 +79,8 @@ For example:
 This Ansible collection also contains a playbook, on how to enable rollbacks:
 [sros_classic_cli_commission.yml](https://raw.githubusercontent.com/nokia/ansible-networking-collections/master/sros/playbooks/sros_classic_cli_commission.yml).
 
-After every successful configuration request one need to make sure, that a new
-checkpoint is created. If the configuration was changed through this Ansible
-plugin, the checkpoint is automatically created.
-
 Snapshot/rollback is used the following way:
+* New checkpoint is created on the begigining of plugin operation.
 * If a configuration request runs into an error, the configuration is restored
   by rolling back to the last checkpoint. It actually translates to a
   rollback-on-error behavior.
@@ -96,6 +93,7 @@ Snapshot/rollback is used the following way:
   to the last checkpoint straight away. Following that approach, syntax and
   semantic checks will be executed - but also we get `change` indication
   including the list of differences, if `--diff` option was provided.
+* Created checkpoint is deleted just before the end of plugin operation.
 
 WARNING:
 * Be aware, that dry-run is implemented as short duration activation of the
@@ -111,6 +109,7 @@ RESTRICTIONS:
 * Some platforms might not support checkpoint/rollback
 * Changes are always written directly to running
 * Operation replace is currently not supported
+* The oldest rollback checkpoint is removed after plugin operation.
 
 ### MD MODE
 To have the NETCONF plugin working, PR [#65718](https://github.com/ansible/ansible/pull/65718) has been integrated into `ansible:devel`. So the change should become active as part of the next Ansible release, which is Ansible 2.10.

--- a/sros/plugins/cliconf/classic.py
+++ b/sros/plugins/cliconf/classic.py
@@ -194,6 +194,6 @@ class Cliconf(CliconfBase):
 
         if match:
             if commit:
-                self.send_command('admin rollback revert {0}'.format(rollback_id))
+                self.send_command('admin rollback revert {0} now'.format(rollback_id))
             return {'diff': match.group(1).strip()}
         return {}

--- a/sros/plugins/cliconf/classic.py
+++ b/sros/plugins/cliconf/classic.py
@@ -138,6 +138,7 @@ class Cliconf(CliconfBase):
 
         try:
             self.send_command('exit all')
+            self.send_command('admin rollback save')  # Save rollback to compare if changes occur. This rollback will be removed upon module completion.
             for cmd in to_list(candidate):
                 if isinstance(cmd, Mapping):
                     requests.append(cmd['command'])
@@ -149,6 +150,7 @@ class Cliconf(CliconfBase):
         except AnsibleConnectionFailure as exc:
             self.send_command('exit all')
             self.send_command('admin rollback revert latest-rb')
+            self.send_command('admin rollback delete latest-rb')
             raise exc
 
         self.send_command('exit all')
@@ -156,7 +158,7 @@ class Cliconf(CliconfBase):
         match = re.search(r'\r?\n-+\r?\n(.*)\r?\n-+\r?\n', rawdiffs, re.DOTALL)
         if match:
             if commit:
-                self.send_command('admin rollback save')
+                pass
             else:
                 # Special hack! We load the config to running and rollback
                 # to just figure out the delta. this might be risky in
@@ -164,8 +166,12 @@ class Cliconf(CliconfBase):
                 # become temporary active.
 
                 self.send_command('admin rollback revert latest-rb')
+            # Remove latest rollback to leave rollback history intact.
+            self.send_command('admin rollback delete latest-rb')
             return {'request': requests, 'response': responses, 'diff': match.group(1)}
         else:
+            # Remove latest rollback to leave rollback history intact.
+            self.send_command('admin rollback delete latest-rb')
             return {'request': requests, 'response': responses}
 
     def get(self, command, prompt=None, answer=None, sendonly=False, output=None, newline=True, check_all=False):
@@ -188,9 +194,6 @@ class Cliconf(CliconfBase):
 
         if match:
             if commit:
-                # After executing the rollback another checkpoint is generated
-                # This is required, to align running and latest-rb for follow-up requests
                 self.send_command('admin rollback revert {0}'.format(rollback_id))
-                self.send_command('admin rollback save')
             return {'diff': match.group(1).strip()}
         return {}


### PR DESCRIPTION
This commit changes how sros rollback feature is used.

**Issue**: every cli_config task leaves new rollback point after execution. When there are 10s tasks on a device some important previously saved rollback point can be overwritten.

_Example: I want to do a massive change on multiple nodes, but to be on a safe side I am creating a rollback point on every node.
I run ansible playbook with multiple cli_tasks ... my rollback point gets overwritten._

**Solution**: Save rollback point when cli_config task starts configuring the device and remove that point upon completion. This will remove only one (oldest) point from the history, but will leave other rollback points intact after executing the task.