### PR TITLE
Suggest to use fully qualified names for actions

### DIFF
--- a/grpc/playbooks/SROS_gNMI_ConfigDemo.yml
+++ b/grpc/playbooks/SROS_gNMI_ConfigDemo.yml
@@ -16,7 +16,7 @@
 
   tasks:
   - name: Get Nodal Configuration (Selective Branches)
-    gnmi_get:
+    nokia.grpc.gnmi_get:
       type: CONFIG
       prefix: /configure
       path:
@@ -31,7 +31,7 @@
       msg: '{{ testout.output }}'
 
   - name: Update Nodal Configuration (using gNMI SET)
-    gnmi_config:
+    nokia.grpc.gnmi_config:
       prefix: configure
       update:
         - path: system/location


### PR DESCRIPTION
That way, users can simply copy&paste without having to worry about adding a 'collections' section.
Ansible project recommends using fully qualified names