### PR TITLE
Add origin namespace support for OpenConfig

### DIFF
--- a/grpc/plugins/connection/gnmi.py
+++ b/grpc/plugins/connection/gnmi.py
@@ -432,14 +432,21 @@ class Connection(NetworkConnectionBase):
         xpath = xpath.strip('\t\n\r /')
         if xpath:
             path_elements = re.split('''/(?=(?:[^\[\]]|\[[^\[\]]+\])*$)''', xpath)
+            origin = {} # Optional namespace element, used for openconfig
             for e in path_elements:
+
+                # Support namespaces with 'origin', required for openconfig
+                ns = e.split(":")
+                if len(ns)>1:
+                    origin['origin'] = ns[0]
+                    e = ns[1]
                 entry = {'name': e.split("[", 1)[0]}
                 eKeys = re.findall('\[(.*?)\]', e)
                 dKeys = dict(x.split('=', 1) for x in eKeys)
                 if dKeys:
                     entry['key'] = dKeys
                 mypath.append(entry)
-            return {'elem': mypath}
+            return {'elem': mypath, **origin}
         return {}
 
     def _decodeXpath(self, path):

--- a/grpc/plugins/connection/gnmi.py
+++ b/grpc/plugins/connection/gnmi.py
@@ -437,9 +437,11 @@ class Connection(NetworkConnectionBase):
 
                 # Support namespaces with 'origin', required for openconfig
                 ns = e.split(":")
-                if len(ns)>1:
+                if len(ns)==2:
                     origin['origin'] = ns[0]
                     e = ns[1]
+                elif len(ns)>2:
+                    raise AnsibleConnectionFailure(f"Invalid path syntax: {e}")
                 entry = {'name': e.split("[", 1)[0]}
                 eKeys = re.findall('\[(.*?)\]', e)
                 dKeys = dict(x.split('=', 1) for x in eKeys)


### PR DESCRIPTION
OpenConfig support requires the setting of the 'origin' attribute for paths, based on the namespace prefix (part before ':')

With a few minor changes, this plug-in can support Openconfig (and any other YANG modules with namespaces)