### PR TITLE
Fix issue due to recent changes in Ansible connection plugin framework

### DIFF
--- a/grpc/plugins/connection/gnmi.py
+++ b/grpc/plugins/connection/gnmi.py
@@ -265,6 +265,7 @@ class Connection(NetworkConnectionBase):
             )
 
         self._connected = False
+        self._sub_plugin = { 'type': 'external' }
 
     def readFile(self, optionName):
         """


### PR DESCRIPTION
Ansible now expects plugins to define ```_sub_plugin``` (and errors out if not set, due to bugs)