### PR TITLE
Set plugin type

### DIFF
--- a/grpc/plugins/connection/gnmi.py
+++ b/grpc/plugins/connection/gnmi.py
@@ -265,6 +265,7 @@ class Connection(NetworkConnectionBase):
             )
 
         self._connected = False
+        self._sub_plugin = { 'type': 'external' }
 
     def readFile(self, optionName):
         """


### PR DESCRIPTION
Changes to Ansible are expecting each plugin to declare its type; this avoids the error