### PR TITLE
Ensure the correct ncclient device handler is passed

### DIFF
--- a/sros/plugins/netconf/md.py
+++ b/sros/plugins/netconf/md.py
@@ -19,7 +19,7 @@ description:
 options:
   ncclient_device_handler:
     type: str
-    default: default
+    default: sros
     description:
       - Specifies the ncclient device-handler name for Nokia SR OS. Please refer to
         the ncclient library documentation for details.


### PR DESCRIPTION
ncclient has a special device handler for netconf.

This change makes sure that Ansible passes the correct device param when initializing the ncclient Manager instance. This shouldn't lead to any backwards incompatibility issues.