### PR TITLE
Fix to get_config for cli-engine classic and config-mode mixed devices

### DIFF
--- a/sros/plugins/cliconf/md.py
+++ b/sros/plugins/cliconf/md.py
@@ -218,6 +218,7 @@ class Cliconf(CliconfBase):
                 self.send_command('discard')
             else:
                 self.send_command('edit-config read-only')
+                self.send_command('environment more false')
                 response = self.send_command(cmd.strip())
             self.send_command('quit-config')
 


### PR DESCRIPTION
Ansible playbooks that are run against devices configured with cli-engine classic-cli md-cli and configuration-mode mixed, cause an Ansible 'command timeout' error at the get_config stage.

Notably, when the module sends the 'info running' command, the Ansible task fails because of the Nokia default prompt to continue (environment more true).

This was successfully tested against TiMOS 21.10.